### PR TITLE
fix: Uncaught TypeError: string is not a function

### DIFF
--- a/js/jquery.circliful.js
+++ b/js/jquery.circliful.js
@@ -1,4 +1,4 @@
-"use strict"
+"use strict";
 
 (function ($) {
 


### PR DESCRIPTION
Script is not working because of missing semicolon
