### PR TITLE
textBelow property added

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,9 @@
         <div class="col-lg-2">
             <div id="test-circle4"></div>
         </div>
+        <div class="col-lg-2">
+            <div id="test-circle5"></div>
+        </div>
     </div>
 
 
@@ -97,6 +100,17 @@
             iconPosition: 'middle',
             multiPercentage: 1,
             text: 'No Kids'
+        });
+
+        $("#test-circle5").circliful({
+            animationStep: 5,
+            foregroundBorderWidth: 5,
+            backgroundBorderWidth: 15,
+            percent: 80,            
+            icon: 'f0a0',
+            iconPosition: 'middle',
+            text: 'Space Left',            
+            textBelow: true
         });
     });
 

--- a/js/jquery.circliful.js
+++ b/js/jquery.circliful.js
@@ -34,7 +34,8 @@
             textStyle: null,
             textColor: '#666',
             multiPercentage: 0,
-            percentages: null
+            percentages: null,
+            textBelow: false
         }, options);
 
         return this.each(function () {
@@ -89,11 +90,17 @@
 
             }
 
-            if(settings.text != null && settings.multiPercentage == 0) {
-                elements += '<text text-anchor="middle" x="100" y="125" style="' + settings.textStyle + '" fill="' + settings.textColor + '">' + settings.text + '</text>';
-            } else if(settings.text != null && settings.multiPercentage == 1) {
-                elements += '<text text-anchor="middle" x="228" y="65" style="' + settings.textStyle + '" fill="' + settings.textColor + '">' + settings.text + '</text>';
-            }
+            if (settings.text != null){
+                if (settings.textBelow){
+                    elements += '<text text-anchor="middle" x="100" y="190" style="' + settings.textStyle + '" fill="' + settings.textColor + '">' + settings.text + '</text>';    
+                }
+                else if (settings.multiPercentage == 0){
+                    elements += '<text text-anchor="middle" x="100" y="125" style="' + settings.textStyle + '" fill="' + settings.textColor + '">' + settings.text + '</text>';    
+                }
+                else if(settings.multiPercentage == 1) {
+                    elements += '<text text-anchor="middle" x="228" y="65" style="' + settings.textStyle + '" fill="' + settings.textColor + '">' + settings.text + '</text>';
+                }
+            }  
 
             if (settings.icon != 'none') {
                 icon = '<text text-anchor="middle" x="' + iconX + '" y="' + iconY + '" class="icon" style="font-size: ' + settings.iconSize + 'px" fill="' + settings.iconColor + '">&#x' + settings.icon + '</text>';


### PR DESCRIPTION
Added a new property "textBelow" to show the string from "text" property below the circle.
It's useful when you want to use an icon on the center of the circle and there's no space for the text there.

Also, included the next example on the index.html code:
![textbelow](https://cloud.githubusercontent.com/assets/8194302/16715870/ba5968ec-46c2-11e6-8d0b-4afe57da66a0.png)

Here's the property description following the readme.md format:

Options
-------------------------

| Option        | Description           | Type           | Default  |
| ------------- |:-------------:| -----:|-----:|
| textBelow    | aligns string of "text" property centered below the circle | boolean | false  |
