### PR TITLE
Add callback function back again

### DIFF
--- a/js/jquery.circliful.js
+++ b/js/jquery.circliful.js
@@ -137,6 +137,7 @@
                     if ((angle) >= (360 / 100 * percent)) {
                         window.clearInterval(timer);
                         last = 1;
+                        callback();
                     } else {
                         angle += angleIncrement;
                         summary += oneStep;


### PR DESCRIPTION
Check issue #78 for more details.  I believe the callback functionality
was either not added when the plugin was upgraded to SVG or probably got
deleted accidently. I have't edited any files not even the
jquery.circliful.min.js file(i believe if this too will have to be done.
)  :)