### PR TITLE
Added settings to show decimals in percentage text

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,25 +60,27 @@ Options
 | backgroundBorderWidth     | width of background circle border | int | 15 |
 | fontColor | color of the percentage | RGB | #aaa |
 | percent     | can be 1 to 100 | integer | 75 |
-| animation     | if the circle should be animated initialy | int | 1 |
+| animation     | if the circle should be animated initially | int | 1 |
 | animationStep     | can be 1 to 100, how fast or slow the animation should be | int | 5 |
 | icon     | font awesome icon, details bellow | string | none |
 | iconSize     | font size of the icon | integer | 30 |
 | iconColor     | color of the icon | RGB | #ccc |
 | iconPosition     | position of the icon (top, bottom, left, right or middle) | string | top |
 | percentageTextSize     | font size of the percentage text | integer | 22 |
-| textAdditionalCss     | additonal css for the percentage text | string | '' |
+| textAdditionalCss     | additional css for the percentage text | string | '' |
 | targetPercent | draws a circle around the main circle | integer | 0 |
 | targetTextSize | font size of the target percentage | integer | 17 |
 | targetColor | fill color of the target circle | RGB | #2980B9 |
 | text | info text shown bellow the percentage in the circle | string | '' |
-| textStyle | css inline style you wanna add to your info text | string | '' |
+| textStyle | css inline style you want to add to your info text | string | '' |
 | textColor | font color of the info text | RGB | #666 |
 | textBelow | aligns string of "text" property centered below the circle | boolean | false |
-| noPercentageSign | to hide the persentage sign | boolean | false |
+| noPercentageSign | to hide the percentage sign | boolean | false |
 | replacePercentageByText | replace the percentage shown in the circle by text | string | null |
 | halfCircle | draw half circle see example bellow | boolean | false |
 | animateInView | animate circle on scroll into view | boolean | false |
+| decimals | number of decimal places to show | integer | 0 |
+| alwaysDecimals | shows decimals while animating instead of only at the end or if less than 1 | boolean | false |
 
 Half Circle
 ------------------

--- a/js/jquery.circliful.js
+++ b/js/jquery.circliful.js
@@ -38,7 +38,9 @@
 			noPercentageSign: false,
 			replacePercentageByText: null,
 			halfCircle: false,
-			animateInView: false
+			animateInView: false,
+			decimals: 0,
+			alwaysDecimals: false
 		}, options);
 
 		return this.each(function () {
@@ -228,9 +230,13 @@
 
 					if (settings.replacePercentageByText == null) {
 						if (settings.halfCircle) {
-							text = parseInt((100 * angle / 360) * 2);
+							text = parseFloat((100 * angle / 360) * 2);
 						} else {
-							text = parseInt((100 * angle / 360));
+							text = parseFloat((100 * angle / 360));
+						}
+						text = text.toFixed(settings.decimals);
+						if (!settings.alwaysDecimals && (percent == 0 || (percent > 1 && last != 1))) {
+							text = parseInt(text);
 						}
 					}
 


### PR DESCRIPTION
I had to implement this change in order to show the decimals of a float for a project I am working on. This fixes issue #96.

Two new options have been added, 'decimals' and 'alwaysDecimals'.

'decimals' is the number of decimal places to show, which defaults to 0 (so that the plugin works as it normally does, not showing decimals). You must set this as a positive number to show decimals.

'alwaysDecimals' defaults to 'false' meaning it will only show the decimals at the end of the animation, or if less than 1. If it is 'true' it will show the decimals while animating.

I also fixed some typos in the README.