### PR TITLE
Fix invalid percentage after animate circle

### DIFF
--- a/js/jquery.circliful.js
+++ b/js/jquery.circliful.js
@@ -239,7 +239,7 @@
                         animateCircle(currentCircle, currentCalculateFill, circleRadius, percent);
                     }
                 } else {
-                    animateCircle(currentCircle, currentCalculateFill, 360, percent);
+                    animateCircle(currentCircle, currentCalculateFill, 360, settings.percent);
                 }
             }
 


### PR DESCRIPTION
Fix invalid `percentage` after animate circle. In function `animate`, while non multiple percentages, the `percentage` variable is declared in invalidly scope and results in `undefined`.
Please see issue [#159](https://github.com/pguso/jquery-plugin-circliful/issues/159) for more info